### PR TITLE
Manually install openjdk-11-jdk in github action workflow

### DIFF
--- a/.github/workflows/client_ft.yml
+++ b/.github/workflows/client_ft.yml
@@ -64,11 +64,15 @@ jobs:
           echo "********************==========*****************************"
           ps -eaf | grep juno
       - uses: actions/checkout@v3.5.2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.11.0
-        with:
-          java-version: "11"
-          distribution: "zulu"
+      - name: Install Java 11
+        run: |
+          java -version || true
+          sudo apt-get update
+          sudo apt-get install openjdk-11-jdk
+          export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+          export PATH=$PATH:$JAVA_HOME/bin
+          echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/" >> ~/.bashrc
+          echo "export PATH=$PATH:$JAVA_HOME/bin" >> ~/.bashrc
       - name: Build with Maven
         run: |
           client/Java/Juno/juno-client-impl/src/test/resources/secrets/gensecrets.sh


### PR DESCRIPTION
<!--

Manually installing java instead of using setup-java module
Purpose - to fix vulnerability issue with setup-java 
CVE-2016-6814

-->