### PR TITLE
fix: set timer.stopped to false by default

### DIFF
--- a/pkg/util/timerwrapper.go
+++ b/pkg/util/timerwrapper.go
@@ -28,7 +28,6 @@ import (
 //
 // timer.C is buffered, so if the timer has just expired,
 // the newly reset timer can actually trigger immediately.
-//
 type TimerWrapper struct {
 	t       *time.Timer
 	stopped bool
@@ -37,10 +36,9 @@ type TimerWrapper struct {
 func NewTimerWrapper(d time.Duration) *TimerWrapper {
 	t := &TimerWrapper{
 		t:       time.NewTimer(d),
-		stopped: true,
+		stopped: false,
 	}
 
-	t.t.Stop()
 	return t
 }
 


### PR DESCRIPTION
### change

1. set timer.stopped to false by default.
2. remove `stop()` when new timer object.