### PR TITLE
solves [#131] removed-unused-commented-code

### DIFF
--- a/test/fakess/requesthandler.go
+++ b/test/fakess/requesthandler.go
@@ -1,23 +1,24 @@
-//  
+//
 //  Copyright 2023 PayPal Inc.
-//  
+//
 //  Licensed to the Apache Software Foundation (ASF) under one or more
 //  contributor license agreements.  See the NOTICE file distributed with
 //  this work for additional information regarding copyright ownership.
 //  The ASF licenses this file to You under the Apache License, Version 2.0
 //  (the "License"); you may not use this file except in compliance with
 //  the License.  You may obtain a copy of the License at
-//  
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-//  
+//
 //  Unless required by applicable law or agreed to in writing, software
 //  distributed under the License is distributed on an "AS IS" BASIS,
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-//  
-  
-// +build
+//
+
+//go:build ignore
+// +build ignore
 
 package main
 
@@ -30,12 +31,6 @@ import (
 
 	"juno/third_party/forked/golang/glog"
 )
-
-//type IRequestHandler interface {
-//	Process(reqCtx *InboundRequestContext) error
-//	Start()
-//	Shutdown()
-//}
 
 type RequestHandler struct {
 	meanDelay   int


### PR DESCRIPTION
 **Description** 
Lines 34 to 38 had unused commented code in https://github.com/paypal/junodb/blob/dev/test/fakess/requesthandler.go

this PR fixes issue [#131]
<img width="391" alt="removed-lines-junodb" src="https://github.com/paypal/junodb/assets/88196222/2872491e-0ef0-48f7-a85e-108eaadbe6b1">

**the motivation for the change**
contributing and getting a PR merged.  This woud motivate me to further explore the project and contribute more

**what issue it fixes**
this PR fixes issue [#131]

**Things I did**
1. removed lines 34-38
2. formatted this go file ( i.e /test/fakess/requesthandler.go) using go fmt.

Let me know if any further changes are required in this PR before it could be merged or any mistakes I'm making.
