### PR TITLE
refactor: Improve Zone Initialization and Node Shards Assignment

### DIFF
--- a/pkg/cluster/zone.go
+++ b/pkg/cluster/zone.go
@@ -49,12 +49,14 @@ func SetMappingAlg(algVersion uint32) {
 	newMappingAlg = true
 }
 
+// NewZone creates a new zone with the specified attributes.
+func NewZone(zoneid uint32, numNodes uint32) *Zone {
+	zone := newZone(zoneid, numNodes)
+	return &zone
+}
+
 func NewZoneFromConfig(zoneid uint32, numNodes uint32, numZones uint32, numShards uint32) *Zone {
-	zone := Zone{
-		Zoneid:   zoneid,
-		NumNodes: numNodes,
-		Nodes:    make([]Node, 1, numNodes),
-	}
+	zone := newZone(zoneid, numNodes)
 
 	// Populate Nodes
 	zone.initShardsAsssignment(numZones, numShards)
@@ -384,4 +386,13 @@ func (list byWeight) Swap(i, j int) {
 // Decreasing order by weight
 func (list byWeight) Less(i, j int) bool {
 	return list[i].weight > list[j].weight
+}
+
+// newZone initializes and returns a new zone with the specified attributes.
+func newZone(zoneid uint32, numNodes uint32) Zone {
+	return Zone{
+		Zoneid:   zoneid,
+		NumNodes: numNodes,
+		Nodes:    make([]Node, 1, numNodes),
+	}
 }

--- a/pkg/etcd/etcdreader.go
+++ b/pkg/etcd/etcdreader.go
@@ -445,7 +445,7 @@ func (cr *EtcdReader) readNodesShards(c *cluster.Cluster, tag string, offset int
 
 		// the prefix fetch is sorted by key in reverse order
 		if c.Zones[zoneid] == nil {
-			c.Zones[zoneid] = cluster.NewZoneFromConfig(uint32(zoneid), uint32(nodeid+1), c.NumZones, c.NumShards)
+			c.Zones[zoneid] = cluster.NewZone(uint32(zoneid), uint32(nodeid+1))
 		}
 
 		c.Zones[zoneid].Nodes[nodeid].StringToNode(uint32(zoneid), uint32(nodeid),


### PR DESCRIPTION
Hi @jostanislas  And JunoDb Team this PR
Refactor `EtcdReader.readNodesShards` Method for More Efficient Zone Initialization and Node shards assignment

**Description:**

**Issue Overview:**

In the `etcd` package and file `etcdreader.go`, the `readNodesShards` method is responsible for reading Nodes Shards assignment through the etcd reader. During this process, it calls `cluster.NewZoneFromConfig` to initialize zones if `c.Zones[zoneid] == nil`. However, there is an opportunity to improve efficiency and avoid redundancy in zone and its nodes initialization.
`cluster.NewZoneFromConfig` not just initialize zone it also execute `zone.initShardsAsssignment(numZones, numShards)` to populate node but in `readNodesShards` we override this logic of populating node though this statement `c.Zones[zoneid].Nodes[nodeid].StringToNode(uint32(zoneid), uint32(nodeid),
			string(ev.Value), TagPrimSecondaryDelimiter, TagShardDelimiter)
` 


**Proposed Solution:**

To enhance code efficiency and eliminate redundancy, I propose refactoring the `readNodesShards` function. Specifically, I suggest replacing the usage of `cluster.NewZoneFromConfig` with the new `NewZone` function. This new function will initialize zones without populating the `Nodes` field, leaving that task to be performed later in the code when it is needed. By making this change, we can avoid overwriting node data during zone initialization and improve overall efficiency.

**Impact:**

This change will optimize the `readNodesShards` function and reduce redundant population of the `Nodes` field during zone initialization. It is expected to have a positive impact on performance.

Additional Context:
This change is suggested as part of ongoing efforts to optimize and improve the codebase of the Juno project. It aims to make zone initialization and Nodes Shards assignment more efficient while maintaining code correctness.

And it Fixes #153